### PR TITLE
Make compatible with 1.16.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,14 +3,14 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# Check these on https://modmuss50.me/fabric.html
-	minecraft_version=1.16.1
-	yarn_mappings=1.16.1+build.21
-	loader_version=0.9.0+build.204
+	minecraft_version=1.16.3
+	yarn_mappings=1.16.3+build.47
+	loader_version=0.10.1+build.209
 
 	#Fabric api
-	fabric_version=0.16.2+build.385-1.16.1
+	fabric_version=0.24.0+build.411-1.16
 
-	loom_version=0.4-SNAPSHOT
+	loom_version=0.5-SNAPSHOT
 
 	# Mod Properties
 	mod_version = 1.0.1
@@ -18,7 +18,7 @@ org.gradle.jvmargs=-Xmx1G
 	archives_base_name = ducts
 
 # LibGui
-libgui_version=2.2.0+1.16.1
+libgui_version=3.1.0+1.16.3
 
 # Kotlin
 	kotlin_version=1.3.61

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.gradle.jvmargs=-Xmx1G
 	loom_version=0.5-SNAPSHOT
 
 	# Mod Properties
-	mod_version = 1.0.1
+	mod_version = 1.0.2
 	maven_group = br.com.brforgers.mods
 	archives_base_name = ducts
 

--- a/src/main/kotlin/br/com/brforgers/mods/ducts/blocks/DuctBlock.kt
+++ b/src/main/kotlin/br/com/brforgers/mods/ducts/blocks/DuctBlock.kt
@@ -25,7 +25,7 @@ import net.minecraft.world.WorldAccess
 class DuctBlock(
         private val screenHandler: ((Int, PlayerInventory, ScreenHandlerContext) -> ScreenHandler)?
 
-        ) : BlockWithEntity(Settings.of(Material.METAL, MaterialColor.STONE).requiresTool().strength(3.0F, 4.8F).sounds(BlockSoundGroup.METAL).nonOpaque()) {
+) : BlockWithEntity(Settings.of(Material.METAL, MaterialColor.STONE).requiresTool().strength(3.0F, 4.8F).sounds(BlockSoundGroup.METAL).nonOpaque()) {
     private val shapeCache = hashMapOf<BlockState, VoxelShape>()
 
     init {
@@ -88,7 +88,25 @@ class DuctBlock(
     }
 
     override fun getStateForNeighborUpdate(state: BlockState, direction: Direction, neighborState: BlockState, world: WorldAccess, pos: BlockPos, neighborPos: BlockPos): BlockState? {
-        return state.with(Props.input[direction], canConnect(neighborState, direction)).with(Props.powered, world.world.isReceivingRedstonePower(pos))
+        return state.with(Props.input[direction], canConnect(neighborState, direction)).with(Props.powered, this.isReceivingRedstonePower(world, pos))
+    }
+
+    private fun isReceivingRedstonePower(world: WorldAccess, pos: BlockPos): Boolean {
+        val blockState: BlockState = world.getBlockState(pos)
+
+        return if (blockState.getWeakRedstonePower(world, pos.down(), Direction.DOWN) > 0) {
+            true
+        } else if (blockState.getWeakRedstonePower(world, pos.up(), Direction.UP) > 0) {
+            true
+        } else if (blockState.getWeakRedstonePower(world, pos.north(), Direction.NORTH) > 0) {
+            true
+        } else if (blockState.getWeakRedstonePower(world, pos.south(), Direction.SOUTH) > 0) {
+            true
+        } else if (blockState.getWeakRedstonePower(world, pos.west(), Direction.WEST) > 0) {
+            true
+        } else {
+            blockState.getWeakRedstonePower(world, pos.east(), Direction.EAST) > 0
+        }
     }
 
     private fun canConnect(other: BlockState, dirToOther: Direction): Boolean {


### PR DESCRIPTION
Bumbs dependencies and work around the removal of `WorldAccess.getWorld` by redoing the redstone powered check
