### PR TITLE
Update target duct cooldown when pushing.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v2.2.0
     - uses: joschi/setup-jdk@v2.3.0
       with:
-        java-version: '16' # The OpenJDK version to make available on the path
+        java-version: '17' # The OpenJDK version to make available on the path
         architecture: 'x64' # defaults to 'x64'
     - run: |
           chmod +x ./gradlew

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,45 @@
+"Don't Be a Jerk" License
+====================================
+#### Okay, so here's the deal.
+
+You'll notice that this repository does not have a license! By default, that means "All Rights Reserved."
+
+That is indeed the case. All rights reserved, as far as the code is concerned.
+
+Art and sound assets are released under the Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0), a summary of which can be found at: https://creativecommons.org/licenses/by-sa/4.0/
+
+©2015-2021 BRForgers Team / The Brazillian Forgers Team
+
+#### Notice
+
+Contribution to this repository means that you are granting us rights over the code that you choose to contribute. If you do not agree with that, do not contribute.
+
+So, why is this here? Well, the rights are reserved, but what that really means is that we choose what to do with the rights. So here you go.
+
+#### You CAN
+- Fork and modify the code.
+- Submit Pull Requests to this repository.
+- Copy portions of this code for use in other projects.
+- Write your own code that uses this code as a dependency. (addon mods!)
+
+#### You CANNOT
+- Redistribute this in its entirety as source or compiled code.
+- Create or distribute code which contains 50% or more Functionally Equivalent Statements* from this repository.
+
+#### You MUST
+- Maintain a visible repository of your code which is inspired by, derived from, or copied from this code. Basically, if you use it, pay it forward. You keep rights to your OWN code, but you still must make your source visible.
+- Not be a jerk**. Seriously, if you're a jerk, you can't use this code. That's part of the agreement.
+
+#### Notes, License & Copyright
+
+*A Functionally Equivalent Statement is a code fragment which, regardless of whitespace and object names, achieves the same result. Basically you can't copy the code, rename the variables, add whitespace and say it's different. It's not.
+
+**A jerk is anyone who attempts to or intends to claim partial or total ownership of the original or repackaged code and/or attempts to or intends to redistribute original or repackaged code without prior express written permission from the owners (BRForgers Team).
+
+Essentially, take this and learn from it! Create addon mods that depend on it! If you see something we can improve, tell us. Submit a Pull Request. The one catch: don't steal! A lot of effort has gone into this, and if you were to take this and call it your own, you'd basically be a big jerk.
+
+Don't be a jerk.
+
+This license is based on CoFH DBaJ license.
+
+©2015-2021 BRForgers Team / The Brazillian Forgers Team

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,16 @@ repositories {
         name = "BuildCraft"
         url = "https://mod-buildcraft.com/maven"
     }
+
+    maven {
+        name = "ClothConfig"
+        url = "https://maven.shedaniel.me/"
+    }
+
+    maven {
+        name = "ModMenu"
+        url = "https://maven.terraformersmc.com/releases/"
+    }
 }
 
 dependencies {
@@ -43,6 +53,10 @@ dependencies {
     //implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     // PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
     // You may need to force-disable transitiveness on them.
+
+    modApi("me.shedaniel.cloth:cloth-config-fabric:${project.clothConfigVersion}") {
+        exclude(group: "net.fabricmc.fabric-api")
+    }
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -25,15 +25,11 @@ repositories {
         name = "BuildCraft"
         url = "https://mod-buildcraft.com/maven"
     }
-
     maven {
-        name = "ClothConfig"
-        url = "https://maven.shedaniel.me/"
-    }
-
-    maven {
-        name = "ModMenu"
-        url = "https://maven.terraformersmc.com/releases/"
+        url "https://www.cursemaven.com"
+        content {
+            includeGroup "curse.maven"
+        }
     }
 }
 
@@ -49,14 +45,9 @@ dependencies {
     modImplementation "net.fabricmc:fabric-language-kotlin:${project.fabric_kotlin_version}+kotlin.${project.kotlin_version}"
 
     include(modImplementation("io.github.cottonmc:LibGui:${project.libgui_version}"))
-    include(modImplementation("alexiil.mc.lib:libblockattributes-all:${project.lba_version}"))
     //implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     // PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
     // You may need to force-disable transitiveness on them.
-
-    modApi("me.shedaniel.cloth:cloth-config-fabric:${project.clothConfigVersion}") {
-        exclude(group: "net.fabricmc.fabric-api")
-    }
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 plugins {
     id 'fabric-loom'
     id 'maven-publish'
-    id "org.jetbrains.kotlin.jvm" version '1.5.10'
+    id "org.jetbrains.kotlin.jvm" version '1.6.0'
 }
 
-sourceCompatibility = JavaVersion.VERSION_16
-targetCompatibility = JavaVersion.VERSION_16
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version
@@ -78,7 +78,7 @@ tasks.withType(JavaCompile) {
     it.options.encoding = "UTF-8"
 
     // Minecraft 1.17 (21w19a) upwards uses Java 16.
-    it.options.release = 16
+    it.options.release = 17
 }
 
 // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
@@ -110,4 +110,4 @@ publishing {
     }
 }
 
-compileKotlin.kotlinOptions.jvmTarget = "16"
+compileKotlin.kotlinOptions.jvmTarget = "17"

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     modImplementation "net.fabricmc:fabric-language-kotlin:${project.fabric_kotlin_version}+kotlin.${project.kotlin_version}"
 
     include(modImplementation("io.github.cottonmc:LibGui:${project.libgui_version}"))
+
+    // Cooldown Coordinator 0.2.1 via cursemaven
+    include(modImplementation("curse.maven:cooldown-coordinator-594072:3697367"))
     //implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     // PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
     // You may need to force-disable transitiveness on them.

--- a/curse_upload
+++ b/curse_upload
@@ -9,7 +9,7 @@ FILE_LOCATION=`echo "./build/libs/$FILE_NAME"`
 CHANGE_LOG=`git log -1 --pretty=format:"%B"`
 
 #See https://github.com/curseforge/api for how to retrieve game version numbers
-JSON=`printf '{"changelog": "%s", "gameVersions": [7499,8516], "releaseType": "release"}' "$CHANGE_LOG"`
+JSON=`printf '{"changelog": "%s", "gameVersions": [7499,8830], "releaseType": "release"}' "$CHANGE_LOG"`
 
 echo "Uploading $FILE_NAME to Curse Forge..."
 echo

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,29 +3,25 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# Check these on https://modmuss50.me/fabric.html
-	minecraft_version=1.17.1
-	yarn_mappings=1.17.1+build.1
-	loader_version=0.11.6
+	minecraft_version=1.18
+	yarn_mappings=1.18+build.1
+	loader_version=0.12.8
 
 	#Fabric api
-	fabric_version=0.36.1+1.17
-
-	loom_version=0.8-SNAPSHOT
+	fabric_version=0.43.1+1.18
+	loom_version=0.10-SNAPSHOT
 
 	# Mod Properties
-	mod_version = 1.1.4+gnifty1
+	mod_version = 1.1.5
 	maven_group = br.com.brforgers.mods
 	archives_base_name = ducts
 
 # LibGui
-libgui_version=4.1.1+1.17.1-rc1
+libgui_version=5.0.0-beta.2+1.18-rc1
 
 # LibBlockAttributes
-lba_version=0.9.0-pre.2
-
-# config file
-clothConfigVersion=5.0.38
+lba_version=0.10.0
 
 # Kotlin
-	kotlin_version=1.5.10
-	fabric_kotlin_version=1.6.1
+	kotlin_version=1.6.0
+	fabric_kotlin_version=1.7.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs=-Xmx1G
 	# Check these on https://modmuss50.me/fabric.html
 	minecraft_version=1.18
 	yarn_mappings=1.18+build.1
-	loader_version=0.12.8
+	loader_version=0.13.3
 
 	#Fabric api
 	fabric_version=0.45.2+1.18

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,19 +8,16 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.12.8
 
 	#Fabric api
-	fabric_version=0.43.1+1.18
+	fabric_version=0.45.2+1.18
 	loom_version=0.10-SNAPSHOT
 
 	# Mod Properties
-	mod_version = 1.1.5
+	mod_version = 1.1.6
 	maven_group = br.com.brforgers.mods
 	archives_base_name = ducts
 
 # LibGui
 libgui_version=5.0.0-beta.2+1.18-rc1
-
-# LibBlockAttributes
-lba_version=0.10.0
 
 # Kotlin
 	kotlin_version=1.6.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.gradle.jvmargs=-Xmx1G
 	loom_version=0.8-SNAPSHOT
 
 	# Mod Properties
-	mod_version = 1.1.4
+	mod_version = 1.1.4+gnifty1
 	maven_group = br.com.brforgers.mods
 	archives_base_name = ducts
 
@@ -22,6 +22,9 @@ libgui_version=4.1.1+1.17.1-rc1
 
 # LibBlockAttributes
 lba_version=0.9.0-pre.2
+
+# config file
+clothConfigVersion=5.0.38
 
 # Kotlin
 	kotlin_version=1.5.10

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/br/com/brforgers/mods/ducts/Ducts.kt
+++ b/src/main/kotlin/br/com/brforgers/mods/ducts/Ducts.kt
@@ -2,7 +2,10 @@ package br.com.brforgers.mods.ducts
 
 import br.com.brforgers.mods.ducts.blockentities.DuctBlockEntity
 import br.com.brforgers.mods.ducts.blocks.DuctBlock
+import br.com.brforgers.mods.ducts.config.DuctsConfig
 import br.com.brforgers.mods.ducts.screens.DuctGuiDescription
+import me.shedaniel.autoconfig.AutoConfig
+import me.shedaniel.autoconfig.serializer.Toml4jConfigSerializer
 import net.fabricmc.api.ModInitializer
 import net.fabricmc.fabric.api.screenhandler.v1.ScreenHandlerRegistry
 import net.minecraft.block.Block
@@ -38,12 +41,15 @@ object Ducts : ModInitializer {
 
     override fun onInitialize(){
         logger.info("Ducts!")
+        AutoConfig.register(DuctsConfig::class.java, ::Toml4jConfigSerializer)
         Registry.register(Registry.BLOCK, DUCT, DUCT_BLOCK)
         Registry.register(Registry.ITEM, DUCT, BlockItem(DUCT_BLOCK, Item.Settings().group(ItemGroup.REDSTONE)))
         Registry.register(Registry.BLOCK_ENTITY_TYPE, DUCT, DuctBlockEntity.type)
 
     }
 
-
+    fun config(): DuctsConfig? {
+        return AutoConfig.getConfigHolder(DuctsConfig::class.java).config
+    }
 
 }

--- a/src/main/kotlin/br/com/brforgers/mods/ducts/Ducts.kt
+++ b/src/main/kotlin/br/com/brforgers/mods/ducts/Ducts.kt
@@ -5,7 +5,6 @@ import br.com.brforgers.mods.ducts.blocks.DuctBlock
 import br.com.brforgers.mods.ducts.config.DuctsConfig
 import br.com.brforgers.mods.ducts.screens.DuctGuiDescription
 import me.shedaniel.autoconfig.AutoConfig
-import me.shedaniel.autoconfig.ConfigHolder
 import me.shedaniel.autoconfig.serializer.Toml4jConfigSerializer
 import net.fabricmc.api.ModInitializer
 import net.fabricmc.fabric.api.screenhandler.v1.ScreenHandlerRegistry
@@ -25,8 +24,6 @@ import org.apache.logging.log4j.Logger
 object Ducts : ModInitializer {
     const val MOD_ID = "ducts"
     var logger: Logger = LogManager.getLogger("Ducts")
-
-    lateinit var configHolder : ConfigHolder<DuctsConfig>
 
     val DUCT: Identifier = Identifier(MOD_ID, "duct")
 

--- a/src/main/kotlin/br/com/brforgers/mods/ducts/blockentities/DuctBlockEntity.kt
+++ b/src/main/kotlin/br/com/brforgers/mods/ducts/blockentities/DuctBlockEntity.kt
@@ -47,6 +47,7 @@ class DuctBlockEntity(
         ExtendedScreenHandlerFactory,
         Tickable {
 
+    private var maxCooldown = 8
     var transferCooldown: Int = -1
 
     var customName: Text? = null
@@ -78,6 +79,9 @@ class DuctBlockEntity(
             val stackCopy = this.getStack(0).copy()
             val ret = HopperBlockEntity.transfer(this, outputInv, this.removeStack(0, 1), outputDir.opposite)
             if (ret.isEmpty) {
+                if (outputInv is DuctBlockEntity) {
+                    (outputInv as DuctBlockEntity).transferCooldown = maxCooldown
+                }
                 outputInv.markDirty()
                 return true
             }
@@ -105,7 +109,7 @@ class DuctBlockEntity(
         transferCooldown = 0
 
         if (attemptInsert()) {
-            transferCooldown = 8
+            transferCooldown = maxCooldown
             markDirty()
         }
     }

--- a/src/main/kotlin/br/com/brforgers/mods/ducts/blockentities/DuctBlockEntity.kt
+++ b/src/main/kotlin/br/com/brforgers/mods/ducts/blockentities/DuctBlockEntity.kt
@@ -1,7 +1,5 @@
 package br.com.brforgers.mods.ducts.blockentities
 
-import alexiil.mc.lib.attributes.item.ItemInvUtil
-import alexiil.mc.lib.attributes.item.compat.FixedInventoryVanillaWrapper
 import br.com.brforgers.mods.ducts.Ducts
 import br.com.brforgers.mods.ducts.blocks.DuctBlock
 import br.com.brforgers.mods.ducts.readNbt

--- a/src/main/kotlin/br/com/brforgers/mods/ducts/blockentities/DuctBlockEntity.kt
+++ b/src/main/kotlin/br/com/brforgers/mods/ducts/blockentities/DuctBlockEntity.kt
@@ -96,6 +96,8 @@ class DuctBlockEntity(
 
         if (blockEntity.transferCooldown > 0) return
 
+        blockEntity.transferCooldown = 0
+
         if (attemptInsert(world, pos, state, blockEntity)) {
             blockEntity.transferCooldown = maxCooldown
             blockEntity.markDirty()

--- a/src/main/kotlin/br/com/brforgers/mods/ducts/blockentities/DuctBlockEntity.kt
+++ b/src/main/kotlin/br/com/brforgers/mods/ducts/blockentities/DuctBlockEntity.kt
@@ -11,6 +11,7 @@ import net.fabricmc.fabric.api.transfer.v1.item.InventoryStorage
 import net.fabricmc.fabric.api.transfer.v1.item.ItemStorage
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant
 import net.fabricmc.fabric.api.transfer.v1.storage.StorageUtil
+import net.gnomecraft.cooldowncoordinator.*
 import net.minecraft.block.BlockState
 import net.minecraft.block.entity.HopperBlockEntity
 import net.minecraft.block.entity.LockableContainerBlockEntity
@@ -31,12 +32,13 @@ import net.minecraft.world.World
 class DuctBlockEntity(
     pos : BlockPos, state: BlockState,private val inventory: Inventory = SimpleInventory(1))
     : LockableContainerBlockEntity(type,pos,state), Inventory by inventory,
-        ExtendedScreenHandlerFactory {
+        ExtendedScreenHandlerFactory, CoordinatedCooldown {
 
     init {
         instance = this
     }
 
+    private var lastTickTime: Long = Long.MAX_VALUE
     var transferCooldown: Int = -1
 
     override fun getContainerName(): Text {
@@ -60,18 +62,31 @@ class DuctBlockEntity(
         val outputDir = blockEntity.cachedState[DuctBlock.Props.output]
         val outputInv = HopperBlockEntity.getInventoryAt(world, pos?.offset(outputDir))
 
-        if(outputInv != null){
+        val targetEntity = world!!.getBlockEntity(pos!!.offset(outputDir))
+        val targetWasEmpty: Boolean
+        val transferSucceeded: Boolean
+
+        if (outputInv != null) {
             val stackCopy = blockEntity.getStack(0).copy()
-            val ret = HopperBlockEntity.transfer(blockEntity, outputInv, blockEntity.removeStack(0, 1), outputDir.opposite)
-            if (ret.isEmpty) {
-                outputInv.markDirty()
-                return true
+            targetWasEmpty = CooldownCoordinator.isInventoryEmpty(outputInv)
+            transferSucceeded = HopperBlockEntity.transfer(blockEntity, outputInv, blockEntity.removeStack(0, 1), outputDir.opposite).isEmpty
+            if (!transferSucceeded) {
+                blockEntity.setStack(0, stackCopy)
             }
-            blockEntity.setStack(0, stackCopy)
         } else {
-            val target = ItemStorage.SIDED.find(world, pos?.offset(outputDir),outputDir) ?: return false
-            return StorageUtil.move(InventoryStorage.of(blockEntity.inventory, outputDir), target, { iv: ItemVariant? -> true }, 1, null) > 0
+            val target = ItemStorage.SIDED.find(world, pos?.offset(outputDir),outputDir.opposite) ?: return false
+            targetWasEmpty = CooldownCoordinator.isItemStorageEmpty(target)
+            transferSucceeded = StorageUtil.move(InventoryStorage.of(blockEntity.inventory, outputDir), target, { iv: ItemVariant? -> true }, 1, null) > 0
         }
+
+        if (transferSucceeded) {
+            if (targetWasEmpty) {
+                CooldownCoordinator.notify(targetEntity)
+            }
+            targetEntity?.markDirty()
+            return true
+        }
+
         return false
     }
 
@@ -80,6 +95,7 @@ class DuctBlockEntity(
         if(world.isClient) return
 
         blockEntity!!.transferCooldown--
+        blockEntity.lastTickTime = world.time
 
         if (blockEntity.transferCooldown > 0) return
 
@@ -111,5 +127,15 @@ class DuctBlockEntity(
     companion object {
         val type = FabricBlockEntityTypeBuilder.create(::DuctBlockEntity, Ducts.DUCT_BLOCK).build(null)!!
         @JvmStatic lateinit var instance: DuctBlockEntity
+    }
+
+    override fun notifyCooldown() {
+        val worldTime = this.world?.time ?: Long.MAX_VALUE
+        if (this.lastTickTime >= worldTime) {
+            this.transferCooldown = 7
+        } else {
+            this.transferCooldown = 8
+        }
+        super.markDirty()
     }
 }

--- a/src/main/kotlin/br/com/brforgers/mods/ducts/blockentities/DuctBlockEntity.kt
+++ b/src/main/kotlin/br/com/brforgers/mods/ducts/blockentities/DuctBlockEntity.kt
@@ -1,10 +1,7 @@
 package br.com.brforgers.mods.ducts.blockentities
 
-import alexiil.mc.lib.attributes.SearchOptions
-import alexiil.mc.lib.attributes.item.ItemAttributes
 import alexiil.mc.lib.attributes.item.ItemInvUtil
 import alexiil.mc.lib.attributes.item.compat.FixedInventoryVanillaWrapper
-import alexiil.mc.lib.attributes.item.impl.RejectingItemInsertable
 import br.com.brforgers.mods.ducts.Ducts
 import br.com.brforgers.mods.ducts.blocks.DuctBlock
 import br.com.brforgers.mods.ducts.readNbt
@@ -12,6 +9,10 @@ import br.com.brforgers.mods.ducts.screens.DuctGuiDescription
 import br.com.brforgers.mods.ducts.writeNbt
 import net.fabricmc.fabric.api.`object`.builder.v1.block.entity.FabricBlockEntityTypeBuilder
 import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerFactory
+import net.fabricmc.fabric.api.transfer.v1.item.InventoryStorage
+import net.fabricmc.fabric.api.transfer.v1.item.ItemStorage
+import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant
+import net.fabricmc.fabric.api.transfer.v1.storage.StorageUtil
 import net.minecraft.block.BlockState
 import net.minecraft.block.entity.HopperBlockEntity
 import net.minecraft.block.entity.LockableContainerBlockEntity
@@ -70,13 +71,8 @@ class DuctBlockEntity(
             }
             blockEntity.setStack(0, stackCopy)
         } else {
-            val insertable = ItemAttributes.INSERTABLE[world, pos?.offset(outputDir), SearchOptions.inDirection(outputDir)]
-            if (insertable == RejectingItemInsertable.NULL) {
-                return false
-            }
-            val extractable = FixedInventoryVanillaWrapper(this).extractable
-
-            return ItemInvUtil.move(extractable, insertable, 1) > 0
+            val target = ItemStorage.SIDED.find(world, pos?.offset(outputDir),outputDir) ?: return false
+            return StorageUtil.move(InventoryStorage.of(blockEntity.inventory, outputDir), target, { iv: ItemVariant? -> true }, 1, null) > 0
         }
         return false
     }

--- a/src/main/kotlin/br/com/brforgers/mods/ducts/config/DuctsConfig.kt
+++ b/src/main/kotlin/br/com/brforgers/mods/ducts/config/DuctsConfig.kt
@@ -1,0 +1,25 @@
+package br.com.brforgers.mods.ducts.config
+
+import blue.endless.jankson.Comment;
+import br.com.brforgers.mods.ducts.Ducts
+import me.shedaniel.autoconfig.ConfigData
+import me.shedaniel.autoconfig.annotation.Config
+import me.shedaniel.autoconfig.annotation.ConfigEntry
+
+// Configuration file definition.
+@SuppressWarnings("unused")
+@Config(name = Ducts.MOD_ID)
+class DuctsConfig : ConfigData {
+    @Comment("Allow redstone signal to disable Ducts?")
+    @ConfigEntry.Gui.Tooltip
+    public var redstoneLocksDucts : Boolean = false
+
+    @Comment("Transfer cooldown for target Duct (true for stable sorters)?")
+    @ConfigEntry.Gui.Tooltip
+    public var targetCooldownEnabled : Boolean = true
+
+    @Comment("Transfer cooldown in game ticks (8+ for stable sorters)?")
+    @ConfigEntry.Gui.Tooltip
+    public var maxCooldown : Int = 8
+
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -35,10 +35,10 @@
     "ducts.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.11.3",
+    "fabricloader": ">=0.12.8",
     "fabric": "*",
     "fabric-language-kotlin": "*",
-    "minecraft": "1.17.x"
+    "minecraft": "1.18.x"
   },
   "suggests": {
     "flamingo": "*"


### PR DESCRIPTION

Fixes #4

The Minecraft wiki says, "A hopper that has an item pushed into it from another hopper also starts a 4 tick cooldown period, regardless of whether it pushed or pulled items itself."  I have added a condition to set the 4 redstone tick cooldown on the target duct when pushing.  In my testing, this appears to resolve the ordering problems to give a stable result similar to that of vanilla hoppers.

I am not certain how ducts interact when pushing to hoppers or other hopper-alikes.  I couldn't find a generic way to set the cooldown so alternating ducts and hoppers could potentially still give strange results.

Go easy on me; this is my first stab at contributing to a fabric project.  :)
