### PR TITLE
Use Cooldown Coordinator to manage item movement cooldowns.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     modImplementation "net.fabricmc:fabric-language-kotlin:${project.fabric_kotlin_version}+kotlin.${project.kotlin_version}"
 
     include(modImplementation("io.github.cottonmc:LibGui:${project.libgui_version}"))
+
+    // Cooldown Coordinator 0.2.1 via cursemaven
+    include(modImplementation("curse.maven:cooldown-coordinator-594072:3697367"))
     //implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     // PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
     // You may need to force-disable transitiveness on them.

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs=-Xmx1G
 	# Check these on https://modmuss50.me/fabric.html
 	minecraft_version=1.18
 	yarn_mappings=1.18+build.1
-	loader_version=0.12.8
+	loader_version=0.13.3
 
 	#Fabric api
 	fabric_version=0.45.2+1.18

--- a/src/main/kotlin/br/com/brforgers/mods/ducts/blockentities/DuctBlockEntity.kt
+++ b/src/main/kotlin/br/com/brforgers/mods/ducts/blockentities/DuctBlockEntity.kt
@@ -11,6 +11,7 @@ import net.fabricmc.fabric.api.transfer.v1.item.InventoryStorage
 import net.fabricmc.fabric.api.transfer.v1.item.ItemStorage
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant
 import net.fabricmc.fabric.api.transfer.v1.storage.StorageUtil
+import net.gnomecraft.cooldowncoordinator.*
 import net.minecraft.block.BlockState
 import net.minecraft.block.entity.HopperBlockEntity
 import net.minecraft.block.entity.LockableContainerBlockEntity
@@ -31,12 +32,13 @@ import net.minecraft.world.World
 class DuctBlockEntity(
     pos : BlockPos, state: BlockState,private val inventory: Inventory = SimpleInventory(1))
     : LockableContainerBlockEntity(type,pos,state), Inventory by inventory,
-        ExtendedScreenHandlerFactory {
+        ExtendedScreenHandlerFactory, CoordinatedCooldown {
 
     init {
         instance = this
     }
 
+    private var lastTickTime: Long = Long.MAX_VALUE
     var transferCooldown: Int = -1
 
     override fun getContainerName(): Text {
@@ -60,18 +62,31 @@ class DuctBlockEntity(
         val outputDir = blockEntity.cachedState[DuctBlock.Props.output]
         val outputInv = HopperBlockEntity.getInventoryAt(world, pos?.offset(outputDir))
 
-        if(outputInv != null){
+        val targetEntity = world!!.getBlockEntity(pos!!.offset(outputDir))
+        val targetWasEmpty: Boolean
+        val transferSucceeded: Boolean
+
+        if (outputInv != null) {
             val stackCopy = blockEntity.getStack(0).copy()
-            val ret = HopperBlockEntity.transfer(blockEntity, outputInv, blockEntity.removeStack(0, 1), outputDir.opposite)
-            if (ret.isEmpty) {
-                outputInv.markDirty()
-                return true
+            targetWasEmpty = CooldownCoordinator.isInventoryEmpty(outputInv)
+            transferSucceeded = HopperBlockEntity.transfer(blockEntity, outputInv, blockEntity.removeStack(0, 1), outputDir.opposite).isEmpty
+            if (!transferSucceeded) {
+                blockEntity.setStack(0, stackCopy)
             }
-            blockEntity.setStack(0, stackCopy)
         } else {
-            val target = ItemStorage.SIDED.find(world, pos?.offset(outputDir),outputDir) ?: return false
-            return StorageUtil.move(InventoryStorage.of(blockEntity.inventory, outputDir), target, { iv: ItemVariant? -> true }, 1, null) > 0
+            val target = ItemStorage.SIDED.find(world, pos?.offset(outputDir),outputDir.opposite) ?: return false
+            targetWasEmpty = CooldownCoordinator.isItemStorageEmpty(target)
+            transferSucceeded = StorageUtil.move(InventoryStorage.of(blockEntity.inventory, outputDir), target, { iv: ItemVariant? -> true }, 1, null) > 0
         }
+
+        if (transferSucceeded) {
+            if (targetWasEmpty) {
+                CooldownCoordinator.notify(targetEntity)
+            }
+            targetEntity?.markDirty()
+            return true
+        }
+
         return false
     }
 
@@ -80,6 +95,7 @@ class DuctBlockEntity(
         if(world.isClient) return
 
         blockEntity!!.transferCooldown--
+        blockEntity.lastTickTime = world.time
 
         if (blockEntity.transferCooldown > 0) return
 
@@ -111,5 +127,15 @@ class DuctBlockEntity(
     companion object {
         val type = FabricBlockEntityTypeBuilder.create(::DuctBlockEntity, Ducts.DUCT_BLOCK).build(null)!!
         @JvmStatic lateinit var instance: DuctBlockEntity
+    }
+
+    override fun notifyCooldown() {
+        val worldTime = this.world?.time ?: Long.MAX_VALUE
+        if (this.lastTickTime >= worldTime) {
+            this.transferCooldown = 7
+        } else {
+            this.transferCooldown = 8
+        }
+        super.markDirty()
     }
 }


### PR DESCRIPTION
Since I created the previous PR, I have learned a lot about vanilla item movement and (after some discussion on the Fabric discord server) created a new mod called [Cooldown Coordinator](https://github.com/gniftygnome/cooldown-coordinator) which is intended to allow mods like Ducts to coordinate their item movement cooldown timings.

Merging this PR would allow Ducts to coordinate item movement cooldowns correctly with vanilla Item Hoppers and also with any other mods which also use Cooldown Coordinator.  It would also require Ducts to either package or depend on the Cooldown Coordinator library.

I would love to hear your feedback about Cooldown Coordinator in general; my hope in the long term is to get it or something similar merged into the Fabric API.  If you are uninterested in resolving #4 please let me know that too; I will stop pestering you about it.

Note:  This PR also fixes a minor error in use of the Fabric transfer API.  The wrong (opposite) side of the target Storage is selected by the current Ducts implementation.